### PR TITLE
Minor edits

### DIFF
--- a/openalexR-webinar.qmd
+++ b/openalexR-webinar.qmd
@@ -11,6 +11,7 @@ format:
     toc_float: true
     resources:
       - data/* 
+    code-link: true
 # filters:
 #   - webr
 ---
@@ -69,7 +70,7 @@ Using this [R base pipe](https://developer.r-project.org/Blog/public/2021/02/21/
 
 ## 🌿 Basic usage
 
-The main function of **openalexR** is `oa_fetch`.
+The main function of **openalexR** is `oa_fetch()`.
 
 ```{r}
 #| eval: false
@@ -84,13 +85,13 @@ Let's start by fetching data on a specific scholarly work using its OpenAlex ID:
 When you know the OpenAlex ID of the work, you do not need to specify `entity = "works"` because entity can be inferred from the first character of `id`.
 However, I specify it here for clarity.
 In other use cases (search, filter), you will almost always want to specify `entity`.
+For a list of all supported entities, see `oa_entities()`.
 :::
 
 ```{r fetch-work}
 work <- oa_fetch(entity = "works", id = "W2741809807", verbose = TRUE)
 work
 ```
-
 
 Now, we can view the output tibble/dataframe, `work`, interactively in RStudio or inspect it with base functions like `str` or `head`.
 
@@ -99,7 +100,7 @@ str(work, max.level = 2)
 ```
 
 **openalexR** also provides the `show_works` function to simplify the result (e.g., remove some columns, keep first/last author) for easy viewing.
-Let us define `print_oa` to wrap the output table in `knitr::kable()` to be displayed nicely on the webpage, but you will most likely not need this function.
+Let us define `print_oa()` to wrap the output table in `knitr::kable()` to be displayed nicely on the webpage, but you will most likely not need this function.
 
 ```{r}
 print_oa <- function(x, fun = show_works) {
@@ -113,7 +114,7 @@ print_oa(work)
 
 ### Filter and search
 
-There are different [filters](https://ropensci.github.io/openalexR/articles/Filters)/arguments you can use in `oa_fetch`, depending on which [entity](https://docs.openalex.org/#data) you're interested in: works, authors, sources, funders, institutions, or concepts.
+There are different [filters](https://ropensci.github.io/openalexR/articles/Filters)/arguments you can use in `oa_fetch()`, depending on which [entity](https://docs.openalex.org/#data) you're interested in: works, authors, sources, funders, institutions, or concepts.
 We show a few examples below.
 
 #### 1. Use `doi` as a [works filter](https://ropensci.github.io/openalexR/articles/Filters.html#works)
@@ -121,7 +122,7 @@ We show a few examples below.
 **Goal**: Fetch information on two works with DOIs `10.1016/j.joi.2017.08.007` and `https://doi.org/10.1007/s11192-013-1221-3`.
 [^1]
 
-[^1]: Either canonical form with [https://doi.org/](https://orcid.org/){.uri} or without will work.
+[^1]: Either canonical form with <https://doi.org/> or without will work.
 
 ```{r}
 works_from_dois <- oa_fetch(
@@ -142,7 +143,7 @@ print_oa(works_from_dois)
 ```{r}
 works_from_orcids <- oa_fetch(
   entity = "works",
-  author.orcid = c("0000-0001-6187-6610", "0000-0002-8517-9411")
+  author.orcid = c("0000-0001-6187-6610", "https://orcid.org/0000-0002-8517-9411")
 )
 
 print_oa(works_from_orcids)
@@ -346,7 +347,7 @@ We leave it as an exercise to the reader to replace this field with `topics` ins
 
 ## 🌵 Advanced topics
 
-### Other parameters of `oa_fetch`
+### Other parameters of `oa_fetch()`
 
 So far, we have seen the argument `options`, which is a list of additional parameters that can be passed to the API.
 `output = "list"` TODO
@@ -373,7 +374,7 @@ TODO
 ### 🌾 N-grams
 
 OpenAlex offers (limited) support for [fulltext N-grams](https://docs.openalex.org/api-entities/works/get-n-grams#fulltext-coverage) of Work entities (these have IDs starting with `"W"`).
-Given a vector of work IDs, `oa_ngrams` returns a dataframe of N-gram data (in the `ngrams` list-column) for each work.
+Given a vector of work IDs, `oa_ngrams()` returns a dataframe of N-gram data (in the `ngrams` list-column) for each work.
 
 ```{r ngrams, fig.height=3}
 ngrams_data <- oa_ngrams(
@@ -401,9 +402,9 @@ ngrams_data |>
   )
 ```
 
-`oa_ngrams` can sometimes be slow because the N-grams data can get pretty big, but given that the N-grams are ["cached via CDN"](https://docs.openalex.org/api-entities/works/get-n-grams#api-endpoint), you may also consider parallelizing for this special case.[^3]
+`oa_ngrams()` can sometimes be slow because the N-grams data can get pretty big, but given that the N-grams are ["cached via CDN"](https://docs.openalex.org/api-entities/works/get-n-grams#api-endpoint), you may also consider parallelizing for this special case.[^3]
 
-[^3]: `oa_ngrams` does this automatically if you have `{curl} >= v5.0.0`
+[^3]: `oa_ngrams()` parallelizes automatically if you have `{curl} >= v5.0.0`
 
 ## 🛤️ Coding challenges
 


### PR DESCRIPTION
A few small edits!
- use code-link:true and add parens to in-line functions for linking
- footnote about doi should link to doi.org
- example of orcid also demonstrates the optionality of https://orcid.org/
- spell out oa_ngram()'s auto-parallelization in footnote
